### PR TITLE
Add watch command / rework scanners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,10 +93,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "array-init"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "backtrace"
@@ -112,12 +115,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -156,16 +153,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
-dependencies = [
- "num-traits",
- "serde",
-]
 
 [[package]]
 name = "clap"
@@ -407,9 +394,9 @@ dependencies = [
  "log",
  "mimalloc",
  "serde",
+ "serde-hex",
  "serde_derive",
  "serde_json",
- "serde_with",
  "serde_yaml",
  "time",
  "walkdir",
@@ -442,12 +429,6 @@ name = "hermit-abi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -500,6 +481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,19 +511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-traits"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "num_cpus"
@@ -587,7 +571,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.13.1",
  "windows-targets 0.48.5",
 ]
 
@@ -684,6 +668,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec 0.6.14",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,21 +701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +711,15 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd52102d3df161c77a887b608d7a4897d7cc112886a9537b738a887a03aaff"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -153,12 +153,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
 
 [[package]]
 name = "cfg-if"
@@ -816,9 +813,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
@@ -836,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -847,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -892,9 +889,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.49"
+version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
+checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1008,7 +1005,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1028,17 +1025,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -1049,9 +1046,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1061,9 +1058,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1073,9 +1070,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1085,9 +1082,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1097,9 +1094,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1109,9 +1106,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1121,9 +1118,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -100,6 +100,12 @@ checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
 dependencies = [
  "nodrop",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -121,6 +127,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bus"
@@ -366,6 +378,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +426,7 @@ dependencies = [
  "hashbrown",
  "log",
  "mimalloc",
+ "notify-debouncer-full",
  "serde",
  "serde-hex",
  "serde_derive",
@@ -400,6 +434,15 @@ dependencies = [
  "serde_yaml",
  "time",
  "walkdir",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -453,10 +496,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "libc"
@@ -472,6 +555,16 @@ checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
@@ -511,10 +604,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
+]
 
 [[package]]
 name = "num-conv"
@@ -563,6 +701,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +753,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -657,6 +805,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -801,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +990,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "hashbrown",
  "log",
  "mimalloc",
+ "notify",
  "notify-debouncer-full",
  "serde",
  "serde-hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "mimalloc",
  "notify",
  "notify-debouncer-full",
+ "regex",
  "serde",
  "serde-hex",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "3286b845d0fccbdd15af433f61c5970e711987036cb468f437ff6badd70f4e24"
 
 [[package]]
 name = "cfg-if"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"
 mimalloc = { version = "0.1", features = ["secure"] }
 notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
 notify-debouncer-full =  {version="0.3", optional=true}
+regex = "1.10.3"
 serde = { version = "1", features = ["rc"] }
 serde-hex = {version="0.1", optional=true}
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ flate2 = { version = "1", features = ["cloudflare_zlib"], default-features = fal
 hashbrown = "0.14"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
 mimalloc = { version = "0.1", features = ["secure"] }
+notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
 notify-debouncer-full =  {version="0.3", optional=true}
 serde = { version = "1", features = ["rc"] }
 serde-hex = {version="0.1", optional=true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,11 @@ repository = "https://github.com/lespea/fse_dump"
 maintenance = { status = "actively-developed" }
 
 [features]
-hex = ["dep:serde-hex"]
+default = ["hex", "extra_id", "watch"]
+
 extra_id = []
-default = ["hex", "extra_id"]
+hex = ["dep:serde-hex"]
+watch = ["dep:notify-debouncer-full"]
 
 [dependencies]
 bus = "2"
@@ -37,8 +39,9 @@ flate2 = { version = "1", features = ["cloudflare_zlib"], default-features = fal
 hashbrown = "0.14"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
 mimalloc = { version = "0.1", features = ["secure"] }
+notify-debouncer-full =  {version="0.3", optional=true}
 serde = { version = "1", features = ["rc"] }
-serde-hex = {version="0.1",optional=true}
+serde-hex = {version="0.1", optional=true}
 serde_derive = "1"
 serde_json = "1"
 serde_yaml = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,17 @@ repository = "https://github.com/lespea/fse_dump"
 [badges]
 maintenance = { status = "actively-developed" }
 
+[features]
+hex = ["dep:serde-hex"]
+extra_id = []
+default = ["hex", "extra_id"]
+
 [dependencies]
 bus = "2"
 byteorder = "1"
 clap = { version = "4", features = ["derive"] }
-clap_complete = "4.5.1"
-color-eyre = { version = "0.6.2", default-features = false }
+clap_complete = "4.5"
+color-eyre = { version = "0.6", default-features = false }
 crossbeam = "0"
 crossbeam-channel = "0"
 csv = "1"
@@ -33,11 +38,11 @@ hashbrown = "0.14"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
 mimalloc = { version = "0.1", features = ["secure"] }
 serde = { version = "1", features = ["rc"] }
-serde-hex = "0.1.0"
+serde-hex = {version="0.1",optional=true}
 serde_derive = "1"
 serde_json = "1"
 serde_yaml = "0.9"
-time = { version = "0.3.32", features = ["local-offset"] }
+time = { version = "0.3", features = ["local-offset"] }
 walkdir = "2"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ hashbrown = "0.14"
 log = { version = "0.4", features = ["max_level_debug", "release_max_level_info"] }
 mimalloc = { version = "0.1", features = ["secure"] }
 serde = { version = "1", features = ["rc"] }
+serde-hex = "0.1.0"
 serde_derive = "1"
 serde_json = "1"
-serde_with = { version = "3.6.1", features = ["hex"], default-features = false }
 serde_yaml = "0.9"
 time = { version = "0.3.32", features = ["local-offset"] }
 walkdir = "2"

--- a/src/file_parser.rs
+++ b/src/file_parser.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::File,
     io::{prelude::*, BufReader, ErrorKind},
-    path::PathBuf,
+    path::Path,
     sync::Arc,
 };
 
@@ -12,7 +12,7 @@ use flate2::read::MultiGzDecoder;
 
 use crate::{record::Record, version};
 
-pub fn parse_file(in_file: PathBuf, bus: &mut Bus<Arc<Record>>) -> Result<()> {
+pub fn parse_file(in_file: &Path, bus: &mut Bus<Arc<Record>>) -> Result<()> {
     let mut reader = BufReader::new(MultiGzDecoder::new(File::open(in_file)?));
 
     loop {
@@ -70,6 +70,8 @@ pub fn parse_file(in_file: PathBuf, bus: &mut Bus<Arc<Record>>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use bus::Bus;
 
     use super::parse_file;
@@ -79,7 +81,8 @@ mod tests {
         let mut bus = Bus::new(4096);
         let mut recv = bus.add_rx();
 
-        parse_file("testfiles/v3/test_1.gz".into(), &mut bus).expect("Couldn't find test file");
+        let path: PathBuf = "testfiles/v3/test_1.gz".into();
+        parse_file(&path, &mut bus).expect("Couldn't find test file");
         drop(bus);
 
         let count = recv.iter().count();

--- a/src/file_parser.rs
+++ b/src/file_parser.rs
@@ -13,6 +13,7 @@ use flate2::read::MultiGzDecoder;
 use crate::{record::Record, version};
 
 pub fn parse_file(in_file: &Path, bus: &mut Bus<Arc<Record>>) -> Result<()> {
+    info!("Parsing {}", in_file.display());
     let mut reader = BufReader::new(MultiGzDecoder::new(File::open(in_file)?));
 
     loop {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -92,13 +92,21 @@ pub fn flag_map() -> &'static RwLock<HashMap<u32, FlagStrs>> {
         combo.insert(0, FlagStrs::default());
 
         for (alt, num) in ALT_FLAGS.iter() {
-            combo.insert(
+            if let Some(old) = combo.insert(
                 *num,
                 FlagStrs {
-                    norm: base.get(num).copied().unwrap_or_default(),
+                    norm: base.remove(num).unwrap_or_default(),
                     alt,
                 },
-            );
+            ) {
+                panic!("Dupe key? {num}/{old:?}")
+            }
+        }
+
+        for (num, b) in base.into_iter() {
+            if let Some(old) = combo.insert(num, FlagStrs { norm: b, alt: "" }) {
+                panic!("Dupe key? {num}/{old:?}")
+            }
         }
 
         RwLock::new(combo)

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,9 +377,13 @@ fn watch(opts: opts::Watch) -> Result<()> {
         move |result: DebounceEventResult| match result {
             Ok(events) => events.iter().for_each(|event| {
                 if event.kind.is_create() {
-                    if let Some(path) = event.paths.first() {
-                        if let Err(err) = send.send_timeout(path.clone(), Duration::from_secs(1)) {
-                            error!("Error processing created file {}: {err}", path.display());
+                    for path in event.paths.iter() {
+                        if path.exists() {
+                            if let Err(err) =
+                                send.send_timeout(path.clone(), Duration::from_secs(1))
+                            {
+                                error!("Error processing created file {}: {err}", path.display());
+                            }
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,6 +369,14 @@ fn watch(opts: opts::Watch) -> Result<()> {
 
     use crate::file_parser::parse_file;
 
+    env_logger::Builder::new()
+        .filter(None, LevelFilter::Info)
+        .write_style(WriteStyle::Always)
+        .target(Target::Stderr)
+        .init();
+
+    color_eyre::install()?;
+
     let (send, recv) = crossbeam_channel::bounded(128);
 
     let mut debouncer = new_debouncer(

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,8 @@ fn generate(gen: Generate) -> Result<()> {
 
 #[cfg(feature = "watch")]
 fn watch(opts: opts::Watch) -> Result<()> {
+    use std::mem;
+
     use notify_debouncer_full::{
         new_debouncer_opt,
         notify::{RecursiveMode, Watcher},
@@ -438,6 +440,8 @@ fn watch(opts: opts::Watch) -> Result<()> {
             debouncer.watcher().watch(&path, RecursiveMode::Recursive)?;
             debouncer.cache().add_root(&path, RecursiveMode::Recursive);
         }
+
+        mem::forget(debouncer);
     } else {
         let mut debouncer = new_debouncer_opt::<_, notify::RecommendedWatcher, FileIdMap>(
             debounce_time,
@@ -472,6 +476,8 @@ fn watch(opts: opts::Watch) -> Result<()> {
             debouncer.watcher().watch(&path, RecursiveMode::Recursive)?;
             debouncer.cache().add_root(&path, RecursiveMode::Recursive);
         }
+
+        mem::forget(debouncer);
     };
 
     crossbeam::scope(|fscope| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,6 +403,7 @@ fn watch(opts: opts::Watch) -> Result<()> {
     )?;
 
     for path in opts.watch_dirs {
+        info!("Watching {}", path.display());
         debouncer.watcher().watch(&path, RecursiveMode::Recursive)?;
         debouncer.cache().add_root(&path, RecursiveMode::Recursive);
     }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -52,6 +52,10 @@ pub struct Watch {
     /// The dirs to watch
     #[arg(default_value = "/System/Volumes/Data/.fseventsd/")]
     pub watch_dirs: Vec<PathBuf>,
+
+    /// Use polling (performance issues only use if the normal watcher doesn't work)
+    #[arg(long)]
+    pub poll: bool,
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -45,6 +45,10 @@ pub struct Watch {
     #[arg(short, long)]
     pub pretty: bool,
 
+    /// Filter events based on the path
+    #[arg(long)]
+    pub filter: Option<String>,
+
     /// The dirs to watch
     #[arg(default_value = "/System/Volumes/Data/.fseventsd/")]
     pub watch_dirs: Vec<PathBuf>,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -46,7 +46,7 @@ pub struct Watch {
     pub pretty: bool,
 
     /// The dirs to watch
-    #[arg(default_value = "/.fseventsd/")]
+    #[arg(default_value = "/System/Volumes/Data/.fseventsd/")]
     pub watch_dirs: Vec<PathBuf>,
 }
 
@@ -115,7 +115,7 @@ pub struct Dump {
 
     /// The fs event files that should be parsed. If any arg is a directory then any file within
     /// that has a filename consisting solely of hex chars will be considered a file to parse
-    #[arg(default_value = "/.fseventsd/")]
+    #[arg(default_value = "/System/Volumes/Data/.fseventsd/")]
     pub files: Vec<PathBuf>,
 }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "hex")]
 use serde_hex::{CompactCapPfx, SerHexOpt};
 
 #[derive(Clone, Debug, Default, Serialize)]
@@ -8,8 +9,9 @@ pub struct Record {
     pub flag: u32,
     pub flags: &'static str,
     pub alt_flags: &'static str,
-    #[serde(with = "SerHexOpt::<CompactCapPfx>")]
+    #[cfg_attr(feature = "hex", serde(with = "SerHexOpt::<CompactCapPfx>"))]
     pub node_id: Option<u64>,
-    #[serde(with = "SerHexOpt::<CompactCapPfx>")]
+    #[cfg(feature = "extra_id")]
+    #[cfg_attr(feature = "hex", serde(with = "SerHexOpt::<CompactCapPfx>"))]
     pub extra_id: Option<u32>,
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,9 +1,11 @@
+use regex::bytes::Regex;
 #[cfg(feature = "hex")]
-use serde_hex::{CompactCapPfx, SerHexOpt};
+use serde_hex::{CompactCapPfx, SerHex, SerHexOpt};
 
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct Record {
     pub path: String,
+    #[cfg_attr(feature = "hex", serde(with = "SerHex::<CompactCapPfx>"))]
     pub event_id: u64,
     #[serde(skip_serializing)]
     pub flag: u32,
@@ -14,4 +16,28 @@ pub struct Record {
     #[cfg(feature = "extra_id")]
     #[cfg_attr(feature = "hex", serde(with = "SerHexOpt::<CompactCapPfx>"))]
     pub extra_id: Option<u32>,
+}
+
+pub trait RecordFilter {
+    fn filter(&self, rec: &Record) -> bool;
+}
+
+#[derive(Clone, Copy)]
+pub struct NoRecordFilter;
+impl RecordFilter for NoRecordFilter {
+    #[inline]
+    fn filter(&self, _: &Record) -> bool {
+        true
+    }
+}
+
+pub struct PathFilter {
+    pub path_rex: Regex,
+}
+
+impl RecordFilter for PathFilter {
+    #[inline]
+    fn filter(&self, rec: &Record) -> bool {
+        self.path_rex.is_match(rec.path.as_bytes())
+    }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,5 @@
+use serde_hex::{CompactCapPfx, SerHexOpt};
+
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct Record {
     pub path: String,
@@ -6,5 +8,8 @@ pub struct Record {
     pub flag: u32,
     pub flags: &'static str,
     pub alt_flags: &'static str,
+    #[serde(with = "SerHexOpt::<CompactCapPfx>")]
     pub node_id: Option<u64>,
+    #[serde(with = "SerHexOpt::<CompactCapPfx>")]
+    pub extra_id: Option<u32>,
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -111,6 +111,7 @@ where
             };
 
             // V3 contains an as-of-now unknown extra 4-bytes; skip them for now
+            #[allow(unused_variables)]
             let extra_id = if Self::HAS_UNKNOWN_NUM {
                 tlen += 4;
                 Some(reader.read_u32::<NativeEndian>()?)
@@ -127,6 +128,7 @@ where
                     flags: flags.norm,
                     alt_flags: flags.alt,
                     node_id,
+                    #[cfg(feature = "extra_id")]
                     extra_id,
                 },
             )))

--- a/src/version.rs
+++ b/src/version.rs
@@ -111,10 +111,12 @@ where
             };
 
             // V3 contains an as-of-now unknown extra 4-bytes; skip them for now
-            if Self::HAS_UNKNOWN_NUM {
+            let extra_id = if Self::HAS_UNKNOWN_NUM {
                 tlen += 4;
-                let _ = reader.read_u32::<NativeEndian>()?;
-            }
+                Some(reader.read_u32::<NativeEndian>()?)
+            } else {
+                None
+            };
 
             Ok(Some((
                 tlen,
@@ -125,6 +127,7 @@ where
                     flags: flags.norm,
                     alt_flags: flags.alt,
                     node_id,
+                    extra_id,
                 },
             )))
         }


### PR DESCRIPTION
1. Add a new "watch" command that watches the specified dirs for new files and tries parsing them
2. Add a path filter to trim down the files that we output (for watch)
3. Make sure all the scan logic is the same no matter what we do
4. Use feature flags to customize bin behavior